### PR TITLE
Update sd.rs

### DIFF
--- a/src/lib/ble/sd.rs
+++ b/src/lib/ble/sd.rs
@@ -12,7 +12,7 @@ pub fn softdevice_config() -> nrf_softdevice::Config {
     nrf_softdevice::Config {
         clock: Some(raw::nrf_clock_lf_cfg_t {
             source: raw::NRF_CLOCK_LF_SRC_RC as u8,
-            rc_ctiv: 4,
+            rc_ctiv: 16,
             rc_temp_ctiv: 2,
             accuracy: raw::NRF_CLOCK_LF_ACCURACY_500_PPM as u8,
         }),


### PR DESCRIPTION
The recommended configuration for NRF_CLOCK_LF_SRC_RC on nRF52 is rc_ctiv=16 and rc_temp_ctiv=2. This will ensure calibration at least once every 8 seconds and for temperature changes of 0.5 degrees Celsius every 4 seconds.